### PR TITLE
Correction Tailor

### DIFF
--- a/DefInjected/WorkTypeDef/WorkTypes.xml
+++ b/DefInjected/WorkTypeDef/WorkTypes.xml
@@ -32,11 +32,11 @@
     <Art.description>Les artistes produisent de belles œuvres d'art.</Art.description>
     <Art.verb>Produire une œuvre</Art.verb>
 	
-	<Tailoring.labelShort>Tailleur</Tailoring.labelShort>
-	<Tailoring.pawnLabel>Tailleur</Tailoring.pawnLabel>
-	<Tailoring.gerundLabel>en taillant</Tailoring.gerundLabel>
-	<Tailoring.verb>Tailler</Tailoring.verb>
-	<Tailoring.description>Taille des pierres.</Tailoring.description>
+	<Tailoring.labelShort>Couturier</Tailoring.labelShort>
+	<Tailoring.pawnLabel>Couturier</Tailoring.pawnLabel>
+	<Tailoring.gerundLabel>Couture</Tailoring.gerundLabel>
+	<Tailoring.verb>Confectionner</Tailoring.verb>
+	<Tailoring.description>Les couturiers confectionnent des vêtements.</Tailoring.description>
 
 	<Smithing.labelShort>Forgeron</Smithing.labelShort>
 	<Smithing.pawnLabel>Forgeron</Smithing.pawnLabel>


### PR DESCRIPTION
J'ai renommé le Tailleur (Tailor) en Couturier afin d'éviter la confusion avec le Tailleur de pierre (Stonecutter).