### PR TITLE
Somes changes / An accuracy on the use of orbital tag

### DIFF
--- a/DefInjected/ConceptDef/Concepts_NotedOpportunistic.xml
+++ b/DefInjected/ConceptDef/Concepts_NotedOpportunistic.xml
@@ -19,10 +19,10 @@
   <InteractingWithTraders.helpText>Vous pouvez parler aux personnages avec un "?" au dessus de leur tête.\n\nSélectionnez un colon et cliquez droit sur le personnage avec un "?" au dessus de sa tête.</InteractingWithTraders.helpText>
 
   <Drafting.label>Enrôlement pour le combat</Drafting.label>
-  <Drafting.helpText>Pour contrôler un colon manuellement pour le combat, sélectionnez-le et appuyez sur le bouton ENRÔLER.\n\nUn colon recruté ne fera que ce que vous lui commandez de faire, et ne prendra pas des initiatives de combat. Ceux qui ont des armes les utiliseront quand cela sera possible.\n\nN'enrôlez pas les colons pour logtemps - ils vont mourir de faim et devenir malheureux..</Drafting.helpText>
+  <Drafting.helpText>Pour contrôler un colon manuellement pour le combat, sélectionnez-le et appuyez sur le bouton ENRÔLER.\n\nUn colon recruté ne fera que ce que vous lui commandez de faire, et ne prendra pas des initiatives de combat. Ceux qui ont des armes les utiliseront quand cela sera possible.\n\nN'enrôlez pas les colons pour longtemps - ils vont mourir de faim et devenir malheureux..</Drafting.helpText>
 
   <BuildOrbitalTradeBeacon.label>Construire une balise de commerce orbital</BuildOrbitalTradeBeacon.label>
-  <BuildOrbitalTradeBeacon.helpText>Pour envoyer de l'argent ou des objets aux marchands de passage, vous devez construire une BALISE DE COMMERCE ORBITAL avec une zone de stockage à proximité.</BuildOrbitalTradeBeacon.helpText>
+  <BuildOrbitalTradeBeacon.helpText>Pour envoyer de l'argent ou des objets aux marchands de passage, vous devez construire une BALISE DE COMMERCE ORBITAL avec une zone de stockage à proximité, et utiliser la CONSOLE DE COMMUNICATION pour les contacter lorsque l'un deux passe à proximité</BuildOrbitalTradeBeacon.helpText>
 
   <AnimalsDontAttackDoors.label>Les animaux n'attaquent pas les portes.</AnimalsDontAttackDoors.label>
   <AnimalsDontAttackDoors.helpText>Généralement, les animaux n'attaquent pas les portes.\n\nVous pouvez vous échapper en vous mettant derrière un mur, mais ils vous attendront.</AnimalsDontAttackDoors.helpText>
@@ -34,7 +34,7 @@
   <OpeningComms.helpText>Pour communiquer, sélectionnez un colon et cliquez-droit sur la console de communication.</OpeningComms.helpText>
 
   <DrugAddiction.label>toxicomanie</DrugAddiction.label>
-  <DrugAddiction.helpText>Vous pouvez inspecter le désir de vos colons de prendre des drogues dans leur onglet BESOINS.\n\nTant que leur niveau de besoin est à zéro, leur dépendance passe à un état de «retrait» qui peut avoir divers effets secondaires négatifs.\n\nCependant, après une longue période de retrait, leur dépendance se terminera et le besoin de drogues disparaîtra.</DrugAddiction.helpText>
+  <DrugAddiction.helpText>Vous pouvez inspecter le désir de vos colons de prendre des drogues dans leur onglet BESOINS.\n\nTant que leur niveau de besoin est à zéro, leur dépendance passe à un état d'abstinence qui peut avoir divers effets secondaires négatifs.\n\nCependant, après une longue période d'abstinence, leur dépendance se terminera et le besoin de drogues disparaîtra.</DrugAddiction.helpText>
 
   <DrugPolicies.label>Règle pharmaceutique</DrugPolicies.label>
   <DrugPolicies.helpText>Vous pouvez assigner des colons à prendre des médicaments spécifiques selon un calendrier spécifique. Par exemple, vous pouvez les faire prendre des médicaments contre la malaria régulièrement, ou boire une bière par jour pour rester heureux.\n\nOuvrez l'onglet ASSIGNATIONS et appuyez sur le bouton 'Gérer les règles sur la drogue'. Créer une nouvelle règle , et ensuite affecter la à vos colons.\n\nLes colons peuvent encore prendre des drogues non comprise dans les règles. Vous pouvez leur dire quoi faire, mais ils suivent aussi leurs propres désirs!</DrugPolicies.helpText>


### PR DESCRIPTION
- Tiny grammatical correction. (A letter forgotten)
- Some details on how to use the orbital tag
- "Abstinence" is an better word than "retrait" to signify the impression of lack of settlers