### PR TITLE
Croissance des animaux erronée

### DIFF
--- a/DefInjected/PawnKindDef/Races_Animal_Arid.xml
+++ b/DefInjected/PawnKindDef/Races_Animal_Arid.xml
@@ -44,8 +44,8 @@
   <Gazelle.lifeStages.2.labelPlural>gazelles</Gazelle.lifeStages.2.labelPlural>
   <Gazelle.lifeStages.2.labelMale>daguet gazelle</Gazelle.lifeStages.2.labelMale>
   <Gazelle.lifeStages.2.labelMalePlural>daguets gazelle</Gazelle.lifeStages.2.labelMalePlural>
-  <Gazelle.lifeStages.2.labelFemale>gazelle juvénile femelle</Gazelle.lifeStages.2.labelFemale>
-  <Gazelle.lifeStages.2.labelFemalePlural>gazelles juvéniles femelles</Gazelle.lifeStages.2.labelFemalePlural>
+  <Gazelle.lifeStages.2.labelFemale>gazelle femelle</Gazelle.lifeStages.2.labelFemale>
+  <Gazelle.lifeStages.2.labelFemalePlural>gazelles femelles</Gazelle.lifeStages.2.labelFemalePlural>
   <Gazelle.labelMale>gazelle mâle</Gazelle.labelMale>
   <Gazelle.labelMalePlural>gazelles mâles</Gazelle.labelMalePlural>
   <Gazelle.labelFemale>gazelle femelle</Gazelle.labelFemale>
@@ -65,12 +65,12 @@
   <Iguana.lifeStages.1.labelMalePlural>iguanes infantiles mâles</Iguana.lifeStages.1.labelMalePlural>
   <Iguana.lifeStages.1.labelFemale>iguane infantile femelle</Iguana.lifeStages.1.labelFemale>
   <Iguana.lifeStages.1.labelFemalePlural>iguanes infantiles femelles</Iguana.lifeStages.1.labelFemalePlural>
-  <Iguana.lifeStages.2.label>iguane juvénile</Iguana.lifeStages.2.label>
+  <Iguana.lifeStages.2.label>iguane</Iguana.lifeStages.2.label>
   <Iguana.lifeStages.2.labelPlural>iguanes juvéniles</Iguana.lifeStages.2.labelPlural>
-  <Iguana.lifeStages.2.labelMale>iguane juvénile mâle</Iguana.lifeStages.2.labelMale>
-  <Iguana.lifeStages.2.labelMalePlural>iguanes juvéniles mâles</Iguana.lifeStages.2.labelMalePlural>
-  <Iguana.lifeStages.2.labelFemale>iguane juvénile femelle</Iguana.lifeStages.2.labelFemale>
-  <Iguana.lifeStages.2.labelFemalePlural>iguane juvéniles femelles</Iguana.lifeStages.2.labelFemalePlural>
+  <Iguana.lifeStages.2.labelMale>iguane mâle</Iguana.lifeStages.2.labelMale>
+  <Iguana.lifeStages.2.labelMalePlural>iguanes mâles</Iguana.lifeStages.2.labelMalePlural>
+  <Iguana.lifeStages.2.labelFemale>iguane femelle</Iguana.lifeStages.2.labelFemale>
+  <Iguana.lifeStages.2.labelFemalePlural>iguane femelles</Iguana.lifeStages.2.labelFemalePlural>
   <Iguana.labelMale>iguane mâle</Iguana.labelMale>
   <Iguana.labelMalePlural>iguanes mâles</Iguana.labelMalePlural>
   <Iguana.labelFemale>iguane femelle</Iguana.labelFemale>
@@ -90,12 +90,12 @@
   <Rhinoceros.lifeStages.1.labelMalePlural>rhinocéros infantiles mâles</Rhinoceros.lifeStages.1.labelMalePlural>
   <Rhinoceros.lifeStages.1.labelFemale>rhinocéros infantile femelle</Rhinoceros.lifeStages.1.labelFemale>
   <Rhinoceros.lifeStages.1.labelFemalePlural>rhinocéros infantiles femelles</Rhinoceros.lifeStages.1.labelFemalePlural>
-  <Rhinoceros.lifeStages.2.label>rhinocéros juvénile</Rhinoceros.lifeStages.2.label>
-  <Rhinoceros.lifeStages.2.labelPlural>rhinocéros juvéniles</Rhinoceros.lifeStages.2.labelPlural>
-  <Rhinoceros.lifeStages.2.labelMale>rhinocéros juvénile mâle</Rhinoceros.lifeStages.2.labelMale>
-  <Rhinoceros.lifeStages.2.labelMalePlural>rhinocéros juvéniles mâles</Rhinoceros.lifeStages.2.labelMalePlural>
-  <Rhinoceros.lifeStages.2.labelFemale>rhinocéros juvénile femelle</Rhinoceros.lifeStages.2.labelFemale>
-  <Rhinoceros.lifeStages.2.labelFemalePlural>rhinocéros juvéniles femelles</Rhinoceros.lifeStages.2.labelFemalePlural>
+  <Rhinoceros.lifeStages.2.label>rhinocéros</Rhinoceros.lifeStages.2.label>
+  <Rhinoceros.lifeStages.2.labelPlural>rhinocéros</Rhinoceros.lifeStages.2.labelPlural>
+  <Rhinoceros.lifeStages.2.labelMale>rhinocéros mâle</Rhinoceros.lifeStages.2.labelMale>
+  <Rhinoceros.lifeStages.2.labelMalePlural>rhinocéros mâles</Rhinoceros.lifeStages.2.labelMalePlural>
+  <Rhinoceros.lifeStages.2.labelFemale>rhinocéros femelle</Rhinoceros.lifeStages.2.labelFemale>
+  <Rhinoceros.lifeStages.2.labelFemalePlural>rhinocéros femelles</Rhinoceros.lifeStages.2.labelFemalePlural>
   <Rhinoceros.labelMale>rhinocéros mâle</Rhinoceros.labelMale>
   <Rhinoceros.labelMalePlural>rhinocéros mâles</Rhinoceros.labelMalePlural>
   <Rhinoceros.labelFemale>rhinocéros femelle</Rhinoceros.labelFemale>
@@ -115,12 +115,12 @@
   <Dromedary.lifeStages.1.labelMalePlural>dromadaires infantiles mâles</Dromedary.lifeStages.1.labelMalePlural>
   <Dromedary.lifeStages.1.labelFemale>dromadaire infantile femelle</Dromedary.lifeStages.1.labelFemale>
   <Dromedary.lifeStages.1.labelFemalePlural>dromadaires infantiles femelles</Dromedary.lifeStages.1.labelFemalePlural>
-  <Dromedary.lifeStages.2.label>dromadaire juvénile</Dromedary.lifeStages.2.label>
-  <Dromedary.lifeStages.2.labelPlural>dromadaires juvéniles</Dromedary.lifeStages.2.labelPlural>
-  <Dromedary.lifeStages.2.labelMale>dromadaire juvénile mâle</Dromedary.lifeStages.2.labelMale>
-  <Dromedary.lifeStages.2.labelMalePlural>dromadaires juvéniles mâles</Dromedary.lifeStages.2.labelMalePlural>
-  <Dromedary.lifeStages.2.labelFemale>dromadaire juvénile femelle</Dromedary.lifeStages.2.labelFemale>
-  <Dromedary.lifeStages.2.labelFemalePlural>dromadaires juvéniles femelles</Dromedary.lifeStages.2.labelFemalePlural>
+  <Dromedary.lifeStages.2.label>dromadaire</Dromedary.lifeStages.2.label>
+  <Dromedary.lifeStages.2.labelPlural>dromadaires</Dromedary.lifeStages.2.labelPlural>
+  <Dromedary.lifeStages.2.labelMale>dromadaire mâle</Dromedary.lifeStages.2.labelMale>
+  <Dromedary.lifeStages.2.labelMalePlural>dromadaires mâles</Dromedary.lifeStages.2.labelMalePlural>
+  <Dromedary.lifeStages.2.labelFemale>dromadaire femelle</Dromedary.lifeStages.2.labelFemale>
+  <Dromedary.lifeStages.2.labelFemalePlural>dromadaires femelles</Dromedary.lifeStages.2.labelFemalePlural>
   <Dromedary.labelMale>dromadaire mâle</Dromedary.labelMale>
   <Dromedary.labelMalePlural>dromadaires mâles</Dromedary.labelMalePlural>
   <Dromedary.labelFemale>dromadaire femelle</Dromedary.labelFemale>

--- a/DefInjected/PawnKindDef/Races_Animal_Arid.xml
+++ b/DefInjected/PawnKindDef/Races_Animal_Arid.xml
@@ -34,16 +34,16 @@
   <Gazelle.lifeStages.0.labelMalePlural>faons gazelle</Gazelle.lifeStages.0.labelMalePlural>
   <Gazelle.lifeStages.0.labelFemale>faonne gazelle</Gazelle.lifeStages.0.labelFemale>
   <Gazelle.lifeStages.0.labelFemalePlural>faonnes gazelle</Gazelle.lifeStages.0.labelFemalePlural>
-  <Gazelle.lifeStages.1.label>gazelle infantile</Gazelle.lifeStages.1.label>
-  <Gazelle.lifeStages.1.labelPlural>gazelles infantiles</Gazelle.lifeStages.1.labelPlural>
-  <Gazelle.lifeStages.1.labelMale>hère gazelle</Gazelle.lifeStages.1.labelMale>
-  <Gazelle.lifeStages.1.labelMalePlural>hères gazelle</Gazelle.lifeStages.1.labelMalePlural>
-  <Gazelle.lifeStages.1.labelFemale>gazelle infantile femelle</Gazelle.lifeStages.1.labelFemale>
-  <Gazelle.lifeStages.1.labelFemalePlural>gazelles infantiles femelles</Gazelle.lifeStages.1.labelFemalePlural>
+  <Gazelle.lifeStages.1.label>gazelle juvénile</Gazelle.lifeStages.1.label>
+  <Gazelle.lifeStages.1.labelPlural>gazelles juvéniles</Gazelle.lifeStages.1.labelPlural>
+  <Gazelle.lifeStages.1.labelMale>gazelle juvénile mâle</Gazelle.lifeStages.1.labelMale>
+  <Gazelle.lifeStages.1.labelMalePlural>gazelles juvéniles mâles</Gazelle.lifeStages.1.labelMalePlural>
+  <Gazelle.lifeStages.1.labelFemale>gazelle juvénile femelle</Gazelle.lifeStages.1.labelFemale>
+  <Gazelle.lifeStages.1.labelFemalePlural>gazelles juvéniles femelles</Gazelle.lifeStages.1.labelFemalePlural>
   <Gazelle.lifeStages.2.label>gazelle</Gazelle.lifeStages.2.label>
   <Gazelle.lifeStages.2.labelPlural>gazelles</Gazelle.lifeStages.2.labelPlural>
-  <Gazelle.lifeStages.2.labelMale>daguet gazelle</Gazelle.lifeStages.2.labelMale>
-  <Gazelle.lifeStages.2.labelMalePlural>daguets gazelle</Gazelle.lifeStages.2.labelMalePlural>
+  <Gazelle.lifeStages.2.labelMale>gazelle mâle</Gazelle.lifeStages.2.labelMale>
+  <Gazelle.lifeStages.2.labelMalePlural>gazelles mâles</Gazelle.lifeStages.2.labelMalePlural>
   <Gazelle.lifeStages.2.labelFemale>gazelle femelle</Gazelle.lifeStages.2.labelFemale>
   <Gazelle.lifeStages.2.labelFemalePlural>gazelles femelles</Gazelle.lifeStages.2.labelFemalePlural>
   <Gazelle.labelMale>gazelle mâle</Gazelle.labelMale>
@@ -59,18 +59,18 @@
   <Iguana.lifeStages.0.labelMalePlural>bébés iguanes mâles</Iguana.lifeStages.0.labelMalePlural>
   <Iguana.lifeStages.0.labelFemale>bébé iguane femelle</Iguana.lifeStages.0.labelFemale>
   <Iguana.lifeStages.0.labelFemalePlural>bébés iguanes femelles</Iguana.lifeStages.0.labelFemalePlural>
-  <Iguana.lifeStages.1.label>iguane infantile</Iguana.lifeStages.1.label>
-  <Iguana.lifeStages.1.labelPlural>iguanes infantiles</Iguana.lifeStages.1.labelPlural>
-  <Iguana.lifeStages.1.labelMale>iguane infantile mâle</Iguana.lifeStages.1.labelMale>
-  <Iguana.lifeStages.1.labelMalePlural>iguanes infantiles mâles</Iguana.lifeStages.1.labelMalePlural>
-  <Iguana.lifeStages.1.labelFemale>iguane infantile femelle</Iguana.lifeStages.1.labelFemale>
-  <Iguana.lifeStages.1.labelFemalePlural>iguanes infantiles femelles</Iguana.lifeStages.1.labelFemalePlural>
+  <Iguana.lifeStages.1.label>iguane juvénile</Iguana.lifeStages.1.label>
+  <Iguana.lifeStages.1.labelPlural>iguanes juvéniles</Iguana.lifeStages.1.labelPlural>
+  <Iguana.lifeStages.1.labelMale>iguane juvénile mâle</Iguana.lifeStages.1.labelMale>
+  <Iguana.lifeStages.1.labelMalePlural>iguanes juvéniles mâles</Iguana.lifeStages.1.labelMalePlural>
+  <Iguana.lifeStages.1.labelFemale>iguane juvénile femelle</Iguana.lifeStages.1.labelFemale>
+  <Iguana.lifeStages.1.labelFemalePlural>iguanes juvéniles femelles</Iguana.lifeStages.1.labelFemalePlural>
   <Iguana.lifeStages.2.label>iguane</Iguana.lifeStages.2.label>
-  <Iguana.lifeStages.2.labelPlural>iguanes juvéniles</Iguana.lifeStages.2.labelPlural>
+  <Iguana.lifeStages.2.labelPlural>iguanes</Iguana.lifeStages.2.labelPlural>
   <Iguana.lifeStages.2.labelMale>iguane mâle</Iguana.lifeStages.2.labelMale>
   <Iguana.lifeStages.2.labelMalePlural>iguanes mâles</Iguana.lifeStages.2.labelMalePlural>
   <Iguana.lifeStages.2.labelFemale>iguane femelle</Iguana.lifeStages.2.labelFemale>
-  <Iguana.lifeStages.2.labelFemalePlural>iguane femelles</Iguana.lifeStages.2.labelFemalePlural>
+  <Iguana.lifeStages.2.labelFemalePlural>iguanes femelles</Iguana.lifeStages.2.labelFemalePlural>
   <Iguana.labelMale>iguane mâle</Iguana.labelMale>
   <Iguana.labelMalePlural>iguanes mâles</Iguana.labelMalePlural>
   <Iguana.labelFemale>iguane femelle</Iguana.labelFemale>
@@ -84,12 +84,12 @@
   <Rhinoceros.lifeStages.0.labelMalePlural>bébés rhinocéros mâles</Rhinoceros.lifeStages.0.labelMalePlural>
   <Rhinoceros.lifeStages.0.labelFemale>bébé rhinocéros femelle</Rhinoceros.lifeStages.0.labelFemale>
   <Rhinoceros.lifeStages.0.labelFemalePlural>bébés rhinocéros femelles</Rhinoceros.lifeStages.0.labelFemalePlural>
-  <Rhinoceros.lifeStages.1.label>rhinocéros infantile</Rhinoceros.lifeStages.1.label>
-  <Rhinoceros.lifeStages.1.labelPlural>rhinocéros infantiles</Rhinoceros.lifeStages.1.labelPlural>
-  <Rhinoceros.lifeStages.1.labelMale>rhinocéros infantile mâle</Rhinoceros.lifeStages.1.labelMale>
-  <Rhinoceros.lifeStages.1.labelMalePlural>rhinocéros infantiles mâles</Rhinoceros.lifeStages.1.labelMalePlural>
-  <Rhinoceros.lifeStages.1.labelFemale>rhinocéros infantile femelle</Rhinoceros.lifeStages.1.labelFemale>
-  <Rhinoceros.lifeStages.1.labelFemalePlural>rhinocéros infantiles femelles</Rhinoceros.lifeStages.1.labelFemalePlural>
+  <Rhinoceros.lifeStages.1.label>rhinocéros juvénile</Rhinoceros.lifeStages.1.label>
+  <Rhinoceros.lifeStages.1.labelPlural>rhinocéros juvéniles</Rhinoceros.lifeStages.1.labelPlural>
+  <Rhinoceros.lifeStages.1.labelMale>rhinocéros juvénile mâle</Rhinoceros.lifeStages.1.labelMale>
+  <Rhinoceros.lifeStages.1.labelMalePlural>rhinocéros juvéniles mâles</Rhinoceros.lifeStages.1.labelMalePlural>
+  <Rhinoceros.lifeStages.1.labelFemale>rhinocéros juvénile femelle</Rhinoceros.lifeStages.1.labelFemale>
+  <Rhinoceros.lifeStages.1.labelFemalePlural>rhinocéros juvéniles femelles</Rhinoceros.lifeStages.1.labelFemalePlural>
   <Rhinoceros.lifeStages.2.label>rhinocéros</Rhinoceros.lifeStages.2.label>
   <Rhinoceros.lifeStages.2.labelPlural>rhinocéros</Rhinoceros.lifeStages.2.labelPlural>
   <Rhinoceros.lifeStages.2.labelMale>rhinocéros mâle</Rhinoceros.lifeStages.2.labelMale>
@@ -109,12 +109,12 @@
   <Dromedary.lifeStages.0.labelMalePlural>bébés dromadaires mâles</Dromedary.lifeStages.0.labelMalePlural>
   <Dromedary.lifeStages.0.labelFemale>bébé dromadaire femelle</Dromedary.lifeStages.0.labelFemale>
   <Dromedary.lifeStages.0.labelFemalePlural>bébé dromadaires femelles</Dromedary.lifeStages.0.labelFemalePlural>
-  <Dromedary.lifeStages.1.label>dromadaire infantile</Dromedary.lifeStages.1.label>
-  <Dromedary.lifeStages.1.labelPlural>dromadaires infantiles</Dromedary.lifeStages.1.labelPlural>
-  <Dromedary.lifeStages.1.labelMale>dromadaire infantile mâle</Dromedary.lifeStages.1.labelMale>
-  <Dromedary.lifeStages.1.labelMalePlural>dromadaires infantiles mâles</Dromedary.lifeStages.1.labelMalePlural>
-  <Dromedary.lifeStages.1.labelFemale>dromadaire infantile femelle</Dromedary.lifeStages.1.labelFemale>
-  <Dromedary.lifeStages.1.labelFemalePlural>dromadaires infantiles femelles</Dromedary.lifeStages.1.labelFemalePlural>
+  <Dromedary.lifeStages.1.label>dromadaire juvénile</Dromedary.lifeStages.1.label>
+  <Dromedary.lifeStages.1.labelPlural>dromadaires juvéniles</Dromedary.lifeStages.1.labelPlural>
+  <Dromedary.lifeStages.1.labelMale>dromadaire juvénile mâle</Dromedary.lifeStages.1.labelMale>
+  <Dromedary.lifeStages.1.labelMalePlural>dromadaires juvéniles mâles</Dromedary.lifeStages.1.labelMalePlural>
+  <Dromedary.lifeStages.1.labelFemale>dromadaire juvénile femelle</Dromedary.lifeStages.1.labelFemale>
+  <Dromedary.lifeStages.1.labelFemalePlural>dromadaires juvéniles femelles</Dromedary.lifeStages.1.labelFemalePlural>
   <Dromedary.lifeStages.2.label>dromadaire</Dromedary.lifeStages.2.label>
   <Dromedary.lifeStages.2.labelPlural>dromadaires</Dromedary.lifeStages.2.labelPlural>
   <Dromedary.lifeStages.2.labelMale>dromadaire mâle</Dromedary.lifeStages.2.labelMale>


### PR DESCRIPTION
Le stade 2 des animaux est le stade adulte, prière de faire les modifications qui s'imposent et d'aussi changer les infantiles en juvéniles.

Arid est concerné et je n'ai pas le temps de vérifier pour le moment mais il y a un risque pour que les autres pawnkind le soient aussi.

Une personne a reporté le problème sur le forum ludeon dans la section des bugs. On nous met la pression.