### PR TITLE
Traduction des tags non traduits signalés par b606

### DIFF
--- a/DefInjected/KeyBindingDef/KeyBindings.xml
+++ b/DefInjected/KeyBindingDef/KeyBindings.xml
@@ -66,7 +66,7 @@
   <ToggleDebugActionsMenu.label>Activer le menu d'action</ToggleDebugActionsMenu.label>
   <ToggleDebugLogMenu.label>Activer le menu du journal de débogage</ToggleDebugLogMenu.label>
   <ToggleDebugInspector.label>Activer l'inspecteur de bogues</ToggleDebugInspector.label>
-  <ToggleDebugSettingsMenu.label>Paramètres du mode de déboguge</ToggleDebugSettingsMenu.label>
+  <ToggleDebugSettingsMenu.label>Paramètres du mode de déboguage</ToggleDebugSettingsMenu.label>
 
 
 </LanguageData>

--- a/DefInjected/KeyBindingDef/KeyBindings.xml
+++ b/DefInjected/KeyBindingDef/KeyBindings.xml
@@ -60,13 +60,13 @@
 
   
 
-  <TickOnce.label>tick once</TickOnce.label>
+  <TickOnce.label>Faire passer un instant</TickOnce.label>
   <ToggleGodMode.label>Mode dieu</ToggleGodMode.label>
-  <ToggleDebugLog.label>toggle debug log</ToggleDebugLog.label>
-  <ToggleDebugActionsMenu.label>toggle debug actions menu</ToggleDebugActionsMenu.label>
-  <ToggleDebugLogMenu.label>toggle debug log menu</ToggleDebugLogMenu.label>
-  <ToggleDebugInspector.label>toggle debug inspector</ToggleDebugInspector.label>
-  <ToggleDebugSettingsMenu.label>Paramètres mode debug</ToggleDebugSettingsMenu.label>
+  <ToggleDebugLog.label>Activer le journal de debogage</ToggleDebugLog.label>
+  <ToggleDebugActionsMenu.label>Activer le menu d'action</ToggleDebugActionsMenu.label>
+  <ToggleDebugLogMenu.label>Activer le menu du journal de débogage</ToggleDebugLogMenu.label>
+  <ToggleDebugInspector.label>Activer l'inspecteur de bogues</ToggleDebugInspector.label>
+  <ToggleDebugSettingsMenu.label>Paramètres du mode de déboguge</ToggleDebugSettingsMenu.label>
 
 
 </LanguageData>

--- a/DefInjected/PawnColumnDef/PawnColumns_Misc.xml
+++ b/DefInjected/PawnColumnDef/PawnColumns_Misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <Master.label>master</Master.label>
+  <Master.label>principal</Master.label>
   <AllowedArea.label>zone autorisée</AllowedArea.label>
   <AllowedAreaWide.label>zone autorisée</AllowedAreaWide.label>
   <Outfit.label>tenue vestimentaire actuelle</Outfit.label>

--- a/DefInjected/PawnColumnDef/PawnColumns_Misc.xml
+++ b/DefInjected/PawnColumnDef/PawnColumns_Misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <Master.label>principal</Master.label>
+  <Master.label>maître</Master.label>
   <AllowedArea.label>zone autorisée</AllowedArea.label>
   <AllowedAreaWide.label>zone autorisée</AllowedAreaWide.label>
   <Outfit.label>tenue vestimentaire actuelle</Outfit.label>

--- a/DefInjected/ResearchTabDef/ResearchTabs.xml
+++ b/DefInjected/ResearchTabDef/ResearchTabs.xml
@@ -3,7 +3,7 @@
 
   
 
-  <Main.label>Main</Main.label>
+  <Main.label>Principal</Main.label>
 
 
 </LanguageData>

--- a/DefInjected/StorytellerDef/Storytellers.xml
+++ b/DefInjected/StorytellerDef/Storytellers.xml
@@ -10,7 +10,7 @@
   <Randy.label>Randy "Hasard"</Randy.label>
   <Randy.description>Randy ne respecte pas les règles, oh non. Il créera des évènements aléatoires, sans se soucier de savoir si cela créera une histoire glorieuse ou un désastre complet. C'est bien là son drame.</Randy.description>
 
-  <Tutor.label>Tutor Hidden</Tutor.label>
+  <Tutor.label>Tutorial Caché</Tutor.label>
 
 
 </LanguageData>

--- a/DefInjected/TaleDef/Tales_DoublePawn.xml
+++ b/DefInjected/TaleDef/Tales_DoublePawn.xml
@@ -181,7 +181,7 @@
   <TrainedAnimal.rulePack.rulesStrings.3>image->[human_nameFull] exerçant [trainable_label] avec [animal_nameFull] [circumstance_group]</TrainedAnimal.rulePack.rulesStrings.3>
   <TrainedAnimal.rulePack.rulesStrings.4>train_syn->entraînement</TrainedAnimal.rulePack.rulesStrings.4>
   <TrainedAnimal.rulePack.rulesStrings.5>train_syn->exercices</TrainedAnimal.rulePack.rulesStrings.5>
-  <TrainedAnimal.rulePack.rulesStrings.6>train_syn->coaching</TrainedAnimal.rulePack.rulesStrings.6>
+  <TrainedAnimal.rulePack.rulesStrings.6>train_syn->encadrement</TrainedAnimal.rulePack.rulesStrings.6>
   <TrainedAnimal.rulePack.rulesStrings.7>train_syn->endoctrinement</TrainedAnimal.rulePack.rulesStrings.7>
   <TrainedAnimal.rulePack.rulesStrings.8>train_syn->éducation</TrainedAnimal.rulePack.rulesStrings.8>
   <TrainedAnimal.rulePack.rulesStrings.9>circumstance_phrase->tandis que d'autres regardent</TrainedAnimal.rulePack.rulesStrings.9>

--- a/DefInjected/ThingDef/Smokeleaf.xml
+++ b/DefInjected/ThingDef/Smokeleaf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <SmokeleafJoint.label>smokeleaf joint</SmokeleafJoint.label>
+  <SmokeleafJoint.label>joint de smokeleaf</SmokeleafJoint.label>
   <SmokeleafJoint.description>Feuilles de smokeleaf préparées en petits rouleaux. Ce produit améliore l'humeur, mais augmente également l'appétit, réduit la concentration et ralentit le mouvement. L'utilisation de smokeleaf peut produire une dépendance. Peut être produit sans équipement, à un lieu d'assemblage artisanal.</SmokeleafJoint.description>
   <SmokeleafJoint.ingestible.ingestCommandString>Fumer {0}</SmokeleafJoint.ingestible.ingestCommandString>
   <SmokeleafJoint.ingestible.ingestReportString>Fume {0}.</SmokeleafJoint.ingestible.ingestReportString>

--- a/DefInjected/ThingDef/_Terrain_Extra.xml
+++ b/DefInjected/ThingDef/_Terrain_Extra.xml
@@ -3,93 +3,93 @@
 
   
 
-  <Concrete_Blueprint.label>concrete (blueprint)</Concrete_Blueprint.label>
-  <Concrete_Frame.label>concrete (building)</Concrete_Frame.label>
-  <Concrete_Frame.description>Terrain building in progress.</Concrete_Frame.description>
+  <Concrete_Blueprint.label>béton (plan)</Concrete_Blueprint.label>
+  <Concrete_Frame.label>béton (sol)</Concrete_Frame.label>
+  <Concrete_Frame.description>Construction du terrain en cours.</Concrete_Frame.description>
 
-  <PavedTile_Blueprint.label>paved tile (blueprint)</PavedTile_Blueprint.label>
-  <PavedTile_Frame.label>paved tile (building)</PavedTile_Frame.label>
-  <PavedTile_Frame.description>Terrain building in progress.</PavedTile_Frame.description>
+  <PavedTile_Blueprint.label>carrelage (plan)</PavedTile_Blueprint.label>
+  <PavedTile_Frame.label>carrelage (sol)</PavedTile_Frame.label>
+  <PavedTile_Frame.description>Construction du terrain en cours.</PavedTile_Frame.description>
 
-  <WoodPlankFloor_Blueprint.label>wood floor (blueprint)</WoodPlankFloor_Blueprint.label>
-  <WoodPlankFloor_Frame.label>wood floor (building)</WoodPlankFloor_Frame.label>
-  <WoodPlankFloor_Frame.description>Terrain building in progress.</WoodPlankFloor_Frame.description>
+  <WoodPlankFloor_Blueprint.label>parquet (plan)</WoodPlankFloor_Blueprint.label>
+  <WoodPlankFloor_Frame.label>parquet (sol)</WoodPlankFloor_Frame.label>
+  <WoodPlankFloor_Frame.description>Construction du terrain en cours.</WoodPlankFloor_Frame.description>
 
-  <MetalTile_Blueprint.label>metal tile (blueprint)</MetalTile_Blueprint.label>
-  <MetalTile_Frame.label>metal tile (building)</MetalTile_Frame.label>
-  <MetalTile_Frame.description>Terrain building in progress.</MetalTile_Frame.description>
+  <MetalTile_Blueprint.label>carrelage en métal (plan)</MetalTile_Blueprint.label>
+  <MetalTile_Frame.label>carrelage en métal (sol)</MetalTile_Frame.label>
+  <MetalTile_Frame.description>Construction du terrain en cours.</MetalTile_Frame.description>
 
-  <SilverTile_Blueprint.label>silver tile (blueprint)</SilverTile_Blueprint.label>
-  <SilverTile_Frame.label>silver tile (building)</SilverTile_Frame.label>
-  <SilverTile_Frame.description>Terrain building in progress.</SilverTile_Frame.description>
+  <SilverTile_Blueprint.label>carrelage en argent (plan)</SilverTile_Blueprint.label>
+  <SilverTile_Frame.label>carrelage en argent (sol)</SilverTile_Frame.label>
+  <SilverTile_Frame.description>Construction du terrain en cours.</SilverTile_Frame.description>
 
-  <GoldTile_Blueprint.label>gold tile (blueprint)</GoldTile_Blueprint.label>
-  <GoldTile_Frame.label>gold tile (building)</GoldTile_Frame.label>
-  <GoldTile_Frame.description>Terrain building in progress.</GoldTile_Frame.description>
+  <GoldTile_Blueprint.label>carrelage en or (plan)</GoldTile_Blueprint.label>
+  <GoldTile_Frame.label>carrelage en or (sol)</GoldTile_Frame.label>
+  <GoldTile_Frame.description>Construction du terrain en cours.</GoldTile_Frame.description>
 
-  <SterileTile_Blueprint.label>sterile tile (blueprint)</SterileTile_Blueprint.label>
-  <SterileTile_Frame.label>sterile tile (building)</SterileTile_Frame.label>
-  <SterileTile_Frame.description>Terrain building in progress.</SterileTile_Frame.description>
+  <SterileTile_Blueprint.label>carrelage stérile (plan)</SterileTile_Blueprint.label>
+  <SterileTile_Frame.label>carrelage stérile (sol)</SterileTile_Frame.label>
+  <SterileTile_Frame.description>Construction du terrain en cours.</SterileTile_Frame.description>
 
-  <CarpetRed_Blueprint.label>red carpet (blueprint)</CarpetRed_Blueprint.label>
-  <CarpetRed_Frame.label>red carpet (building)</CarpetRed_Frame.label>
-  <CarpetRed_Frame.description>Terrain building in progress.</CarpetRed_Frame.description>
+  <CarpetRed_Blueprint.label>moquette rouge (plan)</CarpetRed_Blueprint.label>
+  <CarpetRed_Frame.label>moquette rouge (sol)</CarpetRed_Frame.label>
+  <CarpetRed_Frame.description>Construction du terrain en cours.</CarpetRed_Frame.description>
 
-  <CarpetGreen_Blueprint.label>green carpet (blueprint)</CarpetGreen_Blueprint.label>
-  <CarpetGreen_Frame.label>green carpet (building)</CarpetGreen_Frame.label>
-  <CarpetGreen_Frame.description>Terrain building in progress.</CarpetGreen_Frame.description>
+  <CarpetGreen_Blueprint.label>moquette verte (plan)</CarpetGreen_Blueprint.label>
+  <CarpetGreen_Frame.label>moquette verte (sol)</CarpetGreen_Frame.label>
+  <CarpetGreen_Frame.description>Construction du terrain en cours.</CarpetGreen_Frame.description>
 
-  <CarpetBlue_Blueprint.label>blue carpet (blueprint)</CarpetBlue_Blueprint.label>
-  <CarpetBlue_Frame.label>blue carpet (building)</CarpetBlue_Frame.label>
-  <CarpetBlue_Frame.description>Terrain building in progress.</CarpetBlue_Frame.description>
+  <CarpetBlue_Blueprint.label>moquette bleue (plan)</CarpetBlue_Blueprint.label>
+  <CarpetBlue_Frame.label>moquette bleue (sol)</CarpetBlue_Frame.label>
+  <CarpetBlue_Frame.description>Construction du terrain en cours.</CarpetBlue_Frame.description>
 
-  <CarpetCream_Blueprint.label>cream carpet (blueprint)</CarpetCream_Blueprint.label>
-  <CarpetCream_Frame.label>cream carpet (building)</CarpetCream_Frame.label>
-  <CarpetCream_Frame.description>Terrain building in progress.</CarpetCream_Frame.description>
+  <CarpetCream_Blueprint.label>moquette crème (plan)</CarpetCream_Blueprint.label>
+  <CarpetCream_Frame.label>moquette crème (sol)</CarpetCream_Frame.label>
+  <CarpetCream_Frame.description>Construction du terrain en cours.</CarpetCream_Frame.description>
 
-  <CarpetDark_Blueprint.label>dark carpet (blueprint)</CarpetDark_Blueprint.label>
-  <CarpetDark_Frame.label>dark carpet (building)</CarpetDark_Frame.label>
-  <CarpetDark_Frame.description>Terrain building in progress.</CarpetDark_Frame.description>
+  <CarpetDark_Blueprint.label>moquette noire (plan)</CarpetDark_Blueprint.label>
+  <CarpetDark_Frame.label>moquette noire (sol)</CarpetDark_Frame.label>
+  <CarpetDark_Frame.description>Construction du terrain en cours.</CarpetDark_Frame.description>
 
-  <TileSandstone_Blueprint.label>sandstone tile (blueprint)</TileSandstone_Blueprint.label>
-  <TileSandstone_Frame.label>sandstone tile (building)</TileSandstone_Frame.label>
-  <TileSandstone_Frame.description>Terrain building in progress.</TileSandstone_Frame.description>
+  <TileSandstone_Blueprint.label>carrelage en grès (plan)</TileSandstone_Blueprint.label>
+  <TileSandstone_Frame.label>carrelage en grès (sol)</TileSandstone_Frame.label>
+  <TileSandstone_Frame.description>Construction du terrain en cours.</TileSandstone_Frame.description>
 
-  <TileGranite_Blueprint.label>granite tile (blueprint)</TileGranite_Blueprint.label>
-  <TileGranite_Frame.label>granite tile (building)</TileGranite_Frame.label>
-  <TileGranite_Frame.description>Terrain building in progress.</TileGranite_Frame.description>
+  <TileGranite_Blueprint.label>carrelage en granite (plan)</TileGranite_Blueprint.label>
+  <TileGranite_Frame.label>carrelage en granite (sol)</TileGranite_Frame.label>
+  <TileGranite_Frame.description>Construction du terrain en cours.</TileGranite_Frame.description>
 
-  <TileLimestone_Blueprint.label>limestone tile (blueprint)</TileLimestone_Blueprint.label>
-  <TileLimestone_Frame.label>limestone tile (building)</TileLimestone_Frame.label>
-  <TileLimestone_Frame.description>Terrain building in progress.</TileLimestone_Frame.description>
+  <TileLimestone_Blueprint.label>carrelage en calcaire (plan)</TileLimestone_Blueprint.label>
+  <TileLimestone_Frame.label>carrelage en calcaire (sol)</TileLimestone_Frame.label>
+  <TileLimestone_Frame.description>Construction du terrain en cours.</TileLimestone_Frame.description>
 
-  <TileSlate_Blueprint.label>slate tile (blueprint)</TileSlate_Blueprint.label>
-  <TileSlate_Frame.label>slate tile (building)</TileSlate_Frame.label>
-  <TileSlate_Frame.description>Terrain building in progress.</TileSlate_Frame.description>
+  <TileSlate_Blueprint.label>carrelage en ardoise (plan)</TileSlate_Blueprint.label>
+  <TileSlate_Frame.label>carrelage en ardoise (sol)</TileSlate_Frame.label>
+  <TileSlate_Frame.description>Construction du terrain en cours.</TileSlate_Frame.description>
 
-  <TileMarble_Blueprint.label>marble tile (blueprint)</TileMarble_Blueprint.label>
-  <TileMarble_Frame.label>marble tile (building)</TileMarble_Frame.label>
-  <TileMarble_Frame.description>Terrain building in progress.</TileMarble_Frame.description>
+  <TileMarble_Blueprint.label>carrelage en marbre (plan)</TileMarble_Blueprint.label>
+  <TileMarble_Frame.label>carrelage en marbre (sol)</TileMarble_Frame.label>
+  <TileMarble_Frame.description>Construction du terrain en cours.</TileMarble_Frame.description>
 
-  <FlagstoneSandstone_Blueprint.label>sandstone flagstone (blueprint)</FlagstoneSandstone_Blueprint.label>
-  <FlagstoneSandstone_Frame.label>sandstone flagstone (building)</FlagstoneSandstone_Frame.label>
-  <FlagstoneSandstone_Frame.description>Terrain building in progress.</FlagstoneSandstone_Frame.description>
+  <FlagstoneSandstone_Blueprint.label>dalle de grès (plan)</FlagstoneSandstone_Blueprint.label>
+  <FlagstoneSandstone_Frame.label>dalle de grès (sol)</FlagstoneSandstone_Frame.label>
+  <FlagstoneSandstone_Frame.description>Construction du terrain en cours.</FlagstoneSandstone_Frame.description>
 
-  <FlagstoneGranite_Blueprint.label>granite flagstone (blueprint)</FlagstoneGranite_Blueprint.label>
-  <FlagstoneGranite_Frame.label>granite flagstone (building)</FlagstoneGranite_Frame.label>
-  <FlagstoneGranite_Frame.description>Terrain building in progress.</FlagstoneGranite_Frame.description>
+  <FlagstoneGranite_Blueprint.label>dalle de granite (plan)</FlagstoneGranite_Blueprint.label>
+  <FlagstoneGranite_Frame.label>dalle de granite (sol)</FlagstoneGranite_Frame.label>
+  <FlagstoneGranite_Frame.description>Construction du terrain en cours.</FlagstoneGranite_Frame.description>
 
-  <FlagstoneLimestone_Blueprint.label>limestone flagstone (blueprint)</FlagstoneLimestone_Blueprint.label>
-  <FlagstoneLimestone_Frame.label>limestone flagstone (building)</FlagstoneLimestone_Frame.label>
-  <FlagstoneLimestone_Frame.description>Terrain building in progress.</FlagstoneLimestone_Frame.description>
+  <FlagstoneLimestone_Blueprint.label>dalle de calcaire (plan)</FlagstoneLimestone_Blueprint.label>
+  <FlagstoneLimestone_Frame.label>dalle de calcaire (sol)</FlagstoneLimestone_Frame.label>
+  <FlagstoneLimestone_Frame.description>Construction du terrain en cours.</FlagstoneLimestone_Frame.description>
 
-  <FlagstoneSlate_Blueprint.label>slate flagstone (blueprint)</FlagstoneSlate_Blueprint.label>
-  <FlagstoneSlate_Frame.label>slate flagstone (building)</FlagstoneSlate_Frame.label>
-  <FlagstoneSlate_Frame.description>Terrain building in progress.</FlagstoneSlate_Frame.description>
+  <FlagstoneSlate_Blueprint.label>dalle en ardoise (plan)</FlagstoneSlate_Blueprint.label>
+  <FlagstoneSlate_Frame.label>dalle en ardoise (sol)</FlagstoneSlate_Frame.label>
+  <FlagstoneSlate_Frame.description>Construction du terrain en cours.</FlagstoneSlate_Frame.description>
 
-  <FlagstoneMarble_Blueprint.label>marble flagstone (blueprint)</FlagstoneMarble_Blueprint.label>
-  <FlagstoneMarble_Frame.label>marble flagstone (building)</FlagstoneMarble_Frame.label>
-  <FlagstoneMarble_Frame.description>Terrain building in progress.</FlagstoneMarble_Frame.description>
+  <FlagstoneMarble_Blueprint.label>dalle de marbre (plan)</FlagstoneMarble_Blueprint.label>
+  <FlagstoneMarble_Frame.label>dalle de marbre (sol)</FlagstoneMarble_Frame.label>
+  <FlagstoneMarble_Frame.description>Construction du terrain en cours.</FlagstoneMarble_Frame.description>
 
 
 </LanguageData>

--- a/DefInjected/ThoughtDef/Ambrosia.xml
+++ b/DefInjected/ThoughtDef/Ambrosia.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <AmbrosiaHigh.stages.0.label>ambrosia warmth</AmbrosiaHigh.stages.0.label>
-  <AmbrosiaHigh.stages.0.description>That ambrosia makes me feel a little bit more relaxed, but with more energy too.</AmbrosiaHigh.stages.0.description>
+  <AmbrosiaHigh.stages.0.label>sous l'effet d'ambroisie</AmbrosiaHigh.stages.0.label>
+  <AmbrosiaHigh.stages.0.description>L'ambroisie me rend un peu plus détendu(e), tout en me donnant plus d'énergie. C'est une sensation très étrange.</AmbrosiaHigh.stages.0.description>
 
 
   
 
-  <AmbrosiaWithdrawal.stages.1.label>ambrosia withdrawal</AmbrosiaWithdrawal.stages.1.label>
-  <AmbrosiaWithdrawal.stages.1.description>I just feel heavy and cold all the time. I never thought I'd want a piece of fruit so much.</AmbrosiaWithdrawal.stages.1.description>
+  <AmbrosiaWithdrawal.stages.1.label>sevrage d'ambroisie</AmbrosiaWithdrawal.stages.1.label>
+  <AmbrosiaWithdrawal.stages.1.description>Je me sens lourd(e) et j'ai tout le temps froid. Je n'aurais jamais pensé que je voudrais tant un morceau de fruit.</AmbrosiaWithdrawal.stages.1.description>
 
 
 </LanguageData>

--- a/DefInjected/ThoughtDef/Thoughts_Situation_RoomStats.xml
+++ b/DefInjected/ThoughtDef/Thoughts_Situation_RoomStats.xml
@@ -20,7 +20,7 @@
 
   <PrisonCell.stages.0.label>cellule de prison horrible</PrisonCell.stages.0.label>
   <PrisonCell.stages.0.description>Ma cellule de prison est un endroit horrible.</PrisonCell.stages.0.description>
-  <PrisonCell.stages.3.label>decent prison cell</PrisonCell.stages.3.label>
+  <PrisonCell.stages.3.label>cellule de prison décente</PrisonCell.stages.3.label>
   <PrisonCell.stages.3.description>Ma cellule de prison est assez jolie.</PrisonCell.stages.3.description>
   <PrisonCell.stages.4.label>cellule de prison intéressante</PrisonCell.stages.4.label>
   <PrisonCell.stages.4.description>Ma cellule de prison est intéressante.</PrisonCell.stages.4.description>

--- a/Keyed/Credits.xml
+++ b/Keyed/Credits.xml
@@ -20,7 +20,7 @@
   <Credit_Moderator>Modérateurs</Credit_Moderator>
   <Credit_WikiMaster>Maître du Wiki</Credit_WikiMaster>
 
-  <Credits_TitleLanguage>{0} language</Credits_TitleLanguage>
+  <Credits_TitleLanguage>{0} langage</Credits_TitleLanguage>
   <Credit_Writer>Écrivain</Credit_Writer>
   <Credit_Translator>Traducteurs</Credit_Translator>
   <Credit_OpenSourceLibraries>Bibliothèques libres</Credit_OpenSourceLibraries>

--- a/Keyed/Credits.xml
+++ b/Keyed/Credits.xml
@@ -20,7 +20,7 @@
   <Credit_Moderator>Modérateurs</Credit_Moderator>
   <Credit_WikiMaster>Maître du Wiki</Credit_WikiMaster>
 
-  <Credits_TitleLanguage>{0} langage</Credits_TitleLanguage>
+  <Credits_TitleLanguage>Langue : {0}</Credits_TitleLanguage>
   <Credit_Writer>Écrivain</Credit_Writer>
   <Credit_Translator>Traducteurs</Credit_Translator>
   <Credit_OpenSourceLibraries>Bibliothèques libres</Credit_OpenSourceLibraries>

--- a/Keyed/Dialogs_Various.xml
+++ b/Keyed/Dialogs_Various.xml
@@ -180,7 +180,7 @@
   <LightRequirement>Nécessite de la lumière</LightRequirement>
   <Attributes>Attributs</Attributes>
   <LifeSpan>Durée de vie</LifeSpan>
-  <Nutrition>Nutrition</Nutrition>
+  <Nutrition>Ration</Nutrition>
   <Joy>Plaisir</Joy>
   <FoodQuality>Qualité de la nourriture</FoodQuality>
   <WalkSpeedProperty>Vitesse de marche</WalkSpeedProperty>
@@ -242,7 +242,7 @@
   <FormCaravanColonyThingCountTip>Quantité d'articles disponibles pour la caravane.</FormCaravanColonyThingCountTip>
   <PawnsTab>Personnes et animaux</PawnsTab>
   <ItemsTab>Articles</ItemsTab>
-  <CaravanConfigTab>Config</CaravanConfigTab>
+  <CaravanConfigTab>Connfiguration</CaravanConfigTab>
   <CaravanMustHaveAtLeastOneColonist>Vous devez désigner au moins un colon valide pour la nouvelle caravane.</CaravanMustHaveAtLeastOneColonist>
   <CaravanCouldNotFindExitSpot>Impossible de trouver un point de sortie valide.</CaravanCouldNotFindExitSpot>
   <CaravanCouldNotFindPackingSpot>Impossible de trouver un point valide pour l'échange. Verifier si le point de sortie ({0}) est accessible.</CaravanCouldNotFindPackingSpot>
@@ -261,7 +261,7 @@
   <DaysWorthOfFoodTooltip_CantEatLocalPlants>En se basant sur la saison, la température et les conditions actuelles, nous supposons qu'il ne sera PAS possible pour les animaux herbivores de manger des plantes locales. Mais cela peut changer à tout moment.</DaysWorthOfFoodTooltip_CantEatLocalPlants>
   <DaysWorthOfFoodWarningDialog>Votre caravane n'a que {0} jours de nourriture et sera rapidement affamée.\n\nEtes-vous sûr de vouloir créer cette caravane ?</DaysWorthOfFoodWarningDialog>
   <DaysWorthOfFoodWarningDialog_NoFood>Votre caravane ne transporte aucune nourriture et sera rapidement affamée.\n\nEtes-vous sûr de vouloir créer cette caravane ?</DaysWorthOfFoodWarningDialog_NoFood>
-  <CaravanFoodWillRotSoonWarningDialog>A large part of the assigned food will rot soon.\n\nAre you sure you want to form this caravan?</CaravanFoodWillRotSoonWarningDialog>
+  <CaravanFoodWillRotSoonWarningDialog>Une grande part de la nourriture désignée pourrira bientôt.\n\nÊtes-vous sûr(e) de vouloir former cette caravane ?</CaravanFoodWillRotSoonWarningDialog>
   <NoExitDirectionForCaravanChosen>Vous devez choisir une direction de sortie pour la caravane.</NoExitDirectionForCaravanChosen>
   <NoCaravanExitDirectionAvailable>(Pas de direction de sortie disponible)</NoCaravanExitDirectionAvailable>
   <ExitDirection>Direction de sortie </ExitDirection>

--- a/Keyed/GameplayCommands.xml
+++ b/Keyed/GameplayCommands.xml
@@ -193,9 +193,9 @@
 
   <!-- Fulfill request -->
   <CommandFulfillTradeOffer>Réaliser l'offre commerciale</CommandFulfillTradeOffer>
-  <CommandFulfillTradeOfferDesc>Fulfill the settlement's request for goods and claim your reward.</CommandFulfillTradeOfferDesc>
-  <CommandFulfillTradeOfferFailInsufficient>LA caravanne doit avoir {0} pour accomplir cette offre commercial.</CommandFulfillTradeOfferFailInsufficient>
-  <CommandFulfillTradeOfferConfirm>Offer {0} for {1}?</CommandFulfillTradeOfferConfirm>
+  <CommandFulfillTradeOfferDesc>Fournissez à la colonie ce qu'elle demande et réclamez votre récompense.</CommandFulfillTradeOfferDesc>
+  <CommandFulfillTradeOfferFailInsufficient>La caravanne doit avoir {0} pour accomplir cette offre commerciale.</CommandFulfillTradeOfferFailInsufficient>
+  <CommandFulfillTradeOfferConfirm>Offrir {0} pour {1}?</CommandFulfillTradeOfferConfirm>
 
   <!-- Take off -->
   <CommandTakeOff>Decoller</CommandTakeOff>

--- a/Keyed/WITabs.xml
+++ b/Keyed/WITabs.xml
@@ -11,7 +11,7 @@
   <TabCaravanItems>Objets</TabCaravanItems>
 
   
-  <AbandonSliderText>Abandon {{0}}x {0}</AbandonSliderText>
+  <AbandonSliderText>Abandonner {{0}}x {0}</AbandonSliderText>
   <ConfirmAbandonItemDialog>Voulez-vous vraiment abandonner {0} ?\n\nLes objets abandonnés disparaissent et ne pourront jamais être récupérés.</ConfirmAbandonItemDialog>
   <AbandonTip>Abandonner</AbandonTip>
   <AbandonSpecificCountTip>Abandonner un compte spécifique</AbandonSpecificCountTip>


### PR DESCRIPTION
Normalement, tous les tags signalés  dans
 https://github.com/Ludeon/RimWorld-fr/commit/b828dfb16c2436a2273cc16bc631e62845649087
et en ayant besoin ont été traduits.

Excepté : 
- DefInjected/RulePackDef/RulePacks_NameMakers_Factions.xml qui a peut-être besoin de traduction mais dépasse mon niveau de compréhension des codes.
- DefInjected/ThingDef/_Things_Mote.xml pour lequel je ne vois pas par quoi remplacer "Mote".

Idéalement il faudrait aussi vérifier ma traduction de DefInjected/PawnColumnDef/PawnColumns_Misc.xml
où j'ai remplacé "master" par "principal".