### PR TITLE
Gérondifs -> Noms

### DIFF
--- a/DefInjected/WorkTypeDef/WorkTypes.xml
+++ b/DefInjected/WorkTypeDef/WorkTypes.xml
@@ -5,49 +5,49 @@
   <Firefighter.description>Éteindre les incendies dans la colonie.</Firefighter.description>
   <Firefighter.labelShort>Pompier</Firefighter.labelShort>
   <Firefighter.pawnLabel>Pompier</Firefighter.pawnLabel>
-  <Firefighter.gerundLabel>Combat le feu</Firefighter.gerundLabel>
+  <Firefighter.gerundLabel>Combattre le feu</Firefighter.gerundLabel>
   <Firefighter.verb>Éteindre le feu</Firefighter.verb>
 
   <Patient.label>Patient</Patient.label>
   <Patient.description>Se coucher dans un lit médical pour recevoir des soins si votre pronostic vital est engagé.</Patient.description>
   <Patient.labelShort>Patient</Patient.labelShort>
   <Patient.pawnLabel>Patient</Patient.pawnLabel>
-  <Patient.gerundLabel>Se fait soigner</Patient.gerundLabel>
+  <Patient.gerundLabel>Recevoir des soins</Patient.gerundLabel>
   <Patient.verb>Se faire soigner</Patient.verb>
 
   <Doctor.label>Médecin</Doctor.label>
   <Doctor.description>Soigner les malades, leur apporter de la nourriture, les réconforter et effectuer les opérations chirurgicales. Les médecins prendront soin des colons et des prisonniers.</Doctor.description>
   <Doctor.labelShort>Médecin</Doctor.labelShort>
   <Doctor.pawnLabel>Médecin</Doctor.pawnLabel>
-  <Doctor.gerundLabel>Soigne</Doctor.gerundLabel>
+  <Doctor.gerundLabel>Soins</Doctor.gerundLabel>
   <Doctor.verb>Soigner</Doctor.verb>
 
   <PatientBedRest.label>Repos</PatientBedRest.label>
   <PatientBedRest.description>Rester au lit pour récupérer de problèmes médicaux qui ne mettent pas la vie en jeu, du moins dans l'immédiat.</PatientBedRest.description>
   <PatientBedRest.labelShort>Repos</PatientBedRest.labelShort>
   <PatientBedRest.pawnLabel>Patient</PatientBedRest.pawnLabel>
-  <PatientBedRest.gerundLabel>Se repose au lit</PatientBedRest.gerundLabel>
+  <PatientBedRest.gerundLabel>Repos</PatientBedRest.gerundLabel>
   <PatientBedRest.verb>Se mettre au repos</PatientBedRest.verb>
 
   <Flicker.label>Contrôle</Flicker.label>
   <Flicker.description>Gérer les interrupteurs. Par exemple, quand vous choisissez de basculer l'alimentation sur une tourelle, un contrôleur doit appuyer sur l'interrupteur manuellement.</Flicker.description>
   <Flicker.labelShort>Contrôleur</Flicker.labelShort>
   <Flicker.pawnLabel>Contrôleur</Flicker.pawnLabel>
-  <Flicker.gerundLabel>Actionne l'interrupteur</Flicker.gerundLabel>
+  <Flicker.gerundLabel>Gestion des interrupteurs</Flicker.gerundLabel>
   <Flicker.verb>Contrôler</Flicker.verb>
 
   <Warden.label>Geôlier</Warden.label>
   <Warden.description>Gérer, nourrir, tenir compagnie et recruter les prisonniers.</Warden.description>
   <Warden.labelShort>Geôlier</Warden.labelShort>
   <Warden.pawnLabel>Geôlier</Warden.pawnLabel>
-  <Warden.gerundLabel>Surveille</Warden.gerundLabel>
+  <Warden.gerundLabel>Surveillance</Warden.gerundLabel>
   <Warden.verb>Garder</Warden.verb>
 
   <Handling.label>Dressage</Handling.label>
   <Handling.description>Apprivoiser les animaux, les entraîner, les nourrir, les abattre et récolter les produits animaliers tels que les œufs et le lait.</Handling.description>
   <Handling.labelShort>Dresseur</Handling.labelShort>
   <Handling.pawnLabel>Dresseur</Handling.pawnLabel>
-  <Handling.gerundLabel>S'occupe des animaux</Handling.gerundLabel>
+  <Handling.gerundLabel>Soin aux animaux</Handling.gerundLabel>
   <Handling.verb>Dresser</Handling.verb>
 
   <Cooking.label>Cuisine</Cooking.label>
@@ -68,70 +68,70 @@
   <Construction.description>Construire les éléments spécifiés.</Construction.description>
   <Construction.labelShort>Constructeur</Construction.labelShort>
   <Construction.pawnLabel>Constructeur</Construction.pawnLabel>
-  <Construction.gerundLabel>Construit</Construction.gerundLabel>
+  <Construction.gerundLabel>Construction</Construction.gerundLabel>
   <Construction.verb>Construire</Construction.verb>
 
   <Growing.label>Ferme</Growing.label>
   <Growing.description>Planter et récolter dans les champs.</Growing.description>
   <Growing.labelShort>Fermier</Growing.labelShort>
   <Growing.pawnLabel>Fermier</Growing.pawnLabel>
-  <Growing.gerundLabel>S'occupe des plantations</Growing.gerundLabel>
+  <Growing.gerundLabel>Gestion des plantations</Growing.gerundLabel>
   <Growing.verb>Cultiver</Growing.verb>
 
   <Mining.label>Mine</Mining.label>
   <Mining.description>Creuser les zones désignées pour le minage.</Mining.description>
   <Mining.labelShort>Mineur</Mining.labelShort>
   <Mining.pawnLabel>Mineur</Mining.pawnLabel>
-  <Mining.gerundLabel>Mine</Mining.gerundLabel>
+  <Mining.gerundLabel>Minage</Mining.gerundLabel>
   <Mining.verb>Miner</Mining.verb>
 
   <PlantCutting.label>Foresterie</PlantCutting.label>
   <PlantCutting.description>Récolter ou couper les plantes désignées.</PlantCutting.description>
   <PlantCutting.labelShort>Forestier</PlantCutting.labelShort>
   <PlantCutting.pawnLabel>Forestier</PlantCutting.pawnLabel>
-  <PlantCutting.gerundLabel>S'occupe des plantes désignées</PlantCutting.gerundLabel>
+  <PlantCutting.gerundLabel>Coupe des plantes</PlantCutting.gerundLabel>
   <PlantCutting.verb>Couper des plantes</PlantCutting.verb>
 
   <Smithing.label>Forge</Smithing.label>
   <Smithing.description>Créer des armes et des outils à partir de matières premières, soit comme forgeron, soit par usinage.</Smithing.description>
   <Smithing.labelShort>Forgeron</Smithing.labelShort>
   <Smithing.pawnLabel>Forgeron</Smithing.pawnLabel>
-  <Smithing.gerundLabel>Forge</Smithing.gerundLabel>
+  <Smithing.gerundLabel>Forgeage</Smithing.gerundLabel>
   <Smithing.verb>Forger</Smithing.verb>
 
   <Tailoring.label>Couture</Tailoring.label>
   <Tailoring.description>Confectionner des vêtements à partir de matières premières.</Tailoring.description>
   <Tailoring.labelShort>Couturier</Tailoring.labelShort>
   <Tailoring.pawnLabel>Couturier</Tailoring.pawnLabel>
-  <Tailoring.gerundLabel>Coud</Tailoring.gerundLabel>
+  <Tailoring.gerundLabel>Couture</Tailoring.gerundLabel>
   <Tailoring.verb>Coudre</Tailoring.verb>
 
   <Art.label>Art</Art.label>
   <Art.description>Confectionner des œuvres d'art à partir de matières premières.</Art.description>
   <Art.labelShort>Art</Art.labelShort>
   <Art.pawnLabel>Art</Art.pawnLabel>
-  <Art.gerundLabel>Réalise une oeuvre d'art</Art.gerundLabel>
+  <Art.gerundLabel>Création d'oeuvres d'art</Art.gerundLabel>
   <Art.verb>Sculpter</Art.verb>
 
   <Crafting.label>Artisanat</Crafting.label>
   <Crafting.description>Effectuer les travaux peu qualifiés aux postes de travail. Cela inclut la taille de pierre, la fonte, et davantage.</Crafting.description>
   <Crafting.labelShort>Artisant</Crafting.labelShort>
   <Crafting.pawnLabel>Artisant</Crafting.pawnLabel>
-  <Crafting.gerundLabel>Réalise de l'artisanat</Crafting.gerundLabel>
+  <Crafting.gerundLabel>Artisanat</Crafting.gerundLabel>
   <Crafting.verb>Fabriquer</Crafting.verb>
 
   <Hauling.label>Transport</Hauling.label>
   <Hauling.description>Porter les choses là où elles doivent être.</Hauling.description>
   <Hauling.labelShort>Transporteur</Hauling.labelShort>
   <Hauling.pawnLabel>Transporteur</Hauling.pawnLabel>
-  <Hauling.gerundLabel>Transporte</Hauling.gerundLabel>
+  <Hauling.gerundLabel>Transport</Hauling.gerundLabel>
   <Hauling.verb>Transporter</Hauling.verb>
 
   <Cleaning.label>Nettoyage</Cleaning.label>
   <Cleaning.description>Dégager la neige et nettoyer les sols dans la base.</Cleaning.description>
   <Cleaning.labelShort>Nettoyeur</Cleaning.labelShort>
   <Cleaning.pawnLabel>Nettoyeur</Cleaning.pawnLabel>
-  <Cleaning.gerundLabel>Nettoie</Cleaning.gerundLabel>
+  <Cleaning.gerundLabel>Nettoyage</Cleaning.gerundLabel>
   <Cleaning.verb>Nettoyer</Cleaning.verb>
 
   <Research.label>Recherche</Research.label>


### PR DESCRIPTION
Les gérondifs doivent être traduits comme étant les noms des différentes compétences du jeu.