### PR TITLE
Fix the path in normalize-eol.sh

### DIFF
--- a/Notes/scripts/normalize-eol.sh
+++ b/Notes/scripts/normalize-eol.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-cd $(dirname $(readlink -f $0))/..
+cd $(dirname $(readlink -f $0))/../..
 
 find Backstories DefInjected Keyed Notes Strings -name "*.xml" -o -name "*.txt" | xargs dos2unix --keep-bom


### PR DESCRIPTION
The normalize-eol.sh uses a relative path to find the root folder of the project. As @TynanSylvester moved it in a subfolder, it must be modified accordingly.