### PR TITLE
typo + suggestion

### DIFF
--- a/Core/Backstories/Backstories.xml
+++ b/Core/Backstories/Backstories.xml
@@ -2234,7 +2234,7 @@
     <titleShort>tâcheron</titleShort>
     <titleShortFemale>tâcheronne</titleShortFemale>
     <!-- EN: [PAWN_nameDef] was never sure what [PAWN_pronoun] wanted to do with [PAWN_possessive] life. [PAWN_pronoun] spent most of [PAWN_possessive] time doing low-wage jobs and wondering what [PAWN_possessive] future would be like.\n\n[PAWN_pronoun] entertained [PAWN_objective]self with space sims and survival games, dreaming of one day being somewhere more interesting. -->
-    <desc>[PAWN_nameDef] n'a jamais su ce qu'[PAWN_pronoun] voulait faire de sa vie. [PAWN_pronoun] a passé la majeure partie de son temps à faire de petits boulots et à se demander quel serait son avenir.n\n[PAWN_pronoun] se divertissait avec des simulations spatiales et des jeux de survie, rêvant de jours plus intéressants.</desc>
+    <desc>[PAWN_nameDef] n'a jamais su ce qu'[PAWN_pronoun] voulait faire de sa vie. [PAWN_pronoun] a passé la majeure partie de son temps à faire de petits boulots et à se demander quel serait son avenir.\n\n[PAWN_pronoun] se divertissait avec des simulations spatiales et des jeux de survie, rêvant de jours plus intéressants.</desc>
   </Drudge9>
   
   <DrugLieutenant98>

--- a/Core/Keyed/Dialogs_Various.xml
+++ b/Core/Keyed/Dialogs_Various.xml
@@ -861,7 +861,7 @@
   
   <!-- Move caravan and leave prisoners and animals behind -->
   <!-- EN: Some animals or prisoners are trying to join this caravan. If you move it, they won't be able to anymore.\n\nAnimals, prisoners, and downed colonists left behind in a map without any non-downed colonists are considered abandoned and can be captured by the enemies.\n\nAre you sure you want to move your caravan? -->
-  <ConfirmMoveAutoJoinableCaravan>Certains animaux ou prisonniers essaient de rejoindre cette caravane. Si vous la déplacez, ils ne pourront plus le faire.\n\nLes animaux, les prisonniers et les colons abattus laissés dans une zone sans aucun colon valide sont considérés comme abandonnés et peuvent être capturés par les ennemis.n\nÊtes-vous sûr(e) de vouloir déplacer votre caravane ?</ConfirmMoveAutoJoinableCaravan>
+  <ConfirmMoveAutoJoinableCaravan>Certains animaux ou prisonniers essaient de rejoindre cette caravane. Si vous la déplacez, ils ne pourront plus le faire.\n\nLes animaux, les prisonniers et les colons abattus laissés dans une zone sans aucun colon valide sont considérés comme abandonnés et peuvent être capturés par les ennemis.\n\nÊtes-vous sûr(e) de vouloir déplacer votre caravane ?</ConfirmMoveAutoJoinableCaravan>
   
   <!-- Abandon pawn -->
   <!-- EN: Do you really want to banish {1_label}? -->

--- a/Core/Keyed/Time.xml
+++ b/Core/Keyed/Time.xml
@@ -81,9 +81,9 @@
 
   <!-- Misc -->
   <!-- EN: Started -->
-  <Started>Débuté</Started>
+  <Started>Début</Started>
   <!-- EN: Lasted -->
-  <Lasted>Duré</Lasted>
+  <Lasted>Durée</Lasted>
   <!-- EN: occurred {0} ago -->
   <OccurredTimeAgo>c'est arrivé il y a {0}</OccurredTimeAgo>
   

--- a/Royalty/DefInjected/GatheringDef/Gatherings.xml
+++ b/Royalty/DefInjected/GatheringDef/Gatherings.xml
@@ -13,7 +13,7 @@
   <!-- EN: ThroneSpeech -->
   <ThroneSpeech.label>Discours au trône</ThroneSpeech.label>
   <!-- EN: {ORGANIZER_labelShort} is giving a speech from the throne.\n\nIf all goes well, listeners will feel inspired, and gain respect for {ORGANIZER_labelShort}. If it goes poorly, the speech will do social damage. The outcome depends on {ORGANIZER_labelShort}'s social abilities. -->
-  <ThroneSpeech.letterText>{ORGANIZER_labelShort} prononce un discours depuis le trône.n\n\nSi tout se passe bien, les auditeurs se sentiront inspirés et gagneront du respect pour {ORGANIZER_labelShort}. S'il se passe mal, le discours causera des dommages sociaux. Le résultat dépend des capacités sociales de {ORGANIZER_labelShort}.</ThroneSpeech.letterText>
+  <ThroneSpeech.letterText>{ORGANIZER_labelShort} prononce un discours depuis le trône.\n\nSi tout se passe bien, les auditeurs se sentiront inspirés et gagneront du respect pour {ORGANIZER_labelShort}. S'il se passe mal, le discours causera des dommages sociaux. Le résultat dépend des capacités sociales de {ORGANIZER_labelShort}.</ThroneSpeech.letterText>
   <!-- EN: Speech from the throne -->
   <ThroneSpeech.letterTitle>Discours depuis le trône</ThroneSpeech.letterTitle>
   


### PR DESCRIPTION
Encore quelques endroits où des \ avaient sauté devant des n ^^ 

Je suggère également de transformer les actuel verbes "Started" > "Débuté" et "Lasted" > "Duré" en "Début" et "Durée". Je n'ai pas beaucoup de visibilité sur l'utilisation de ces termes, sauf dans le cas suivant : 
![image](https://user-images.githubusercontent.com/7262531/76456296-0dde1c80-63d7-11ea-94da-f1526c6a76dd.png)

Si à chaque fois c'est utilisé comme ça, j'ai trouvé le "Duré" très étrange, et si on veut le transformer en nom et conserver la concordance il faut que les deux soient des noms.

Si ça ne convient pas, retirez-le de la PR, pas de soucis :)