### PR TITLE
change ''sanguin'' en ''joyeux''

### DIFF
--- a/Core/DefInjected/ThoughtDef/Thoughts_Situation_TraitsPerm.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Situation_TraitsPerm.xml
@@ -17,9 +17,9 @@
   <MoodOffsetPessimist.stages.pessimist.description>Pénalité naturelle du trait «pessimiste».</MoodOffsetPessimist.stages.pessimist.description>
   
   <!-- EN: sanguine -->
-  <MoodOffsetSanguine.stages.sanguine.label>sanguin{PAWN_gender ? : e}</MoodOffsetSanguine.stages.sanguine.label>
+  <MoodOffsetSanguine.stages.sanguine.label>joyeu{PAWN_gender ? x : se}</MoodOffsetSanguine.stages.sanguine.label>
   <!-- EN: Natural bonus from 'sanguine' trait. -->
-  <MoodOffsetSanguine.stages.sanguine.description>Bonus de base du trait «sanguin{PAWN_gender ? : e}».</MoodOffsetSanguine.stages.sanguine.description>
+  <MoodOffsetSanguine.stages.sanguine.description>Bonus de base du trait «joyeu{PAWN_gender ? x : se}».</MoodOffsetSanguine.stages.sanguine.description>
   
   <!-- EN: Tortured artist -->
   <MoodOffsetTorturedArtist.stages.Tortured_artist.label>artiste torturé{PAWN_gender ? : e}</MoodOffsetTorturedArtist.stages.Tortured_artist.label>


### PR DESCRIPTION
La pensée ''sanguin'' donne un bonus d'humeur de +12 et correspond au trait traduit comme ''joyeux'', j'ai corrigé cette erreur de traduction.