### PR TITLE
raw food: nourriture crue (et non viande crue)

### DIFF
--- a/Core/DefInjected/ThoughtDef/Thoughts_Memory_Eating.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Memory_Eating.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <LanguageData>
   
   <!-- EN: ate corpse -->
@@ -52,7 +52,7 @@
   <AteLavishMeal.stages.ate_lavish_meal.description>Ce repas était succulent. Mon corps et mon esprit sont revigorés.</AteLavishMeal.stages.ate_lavish_meal.description>
   
   <!-- EN: ate raw food -->
-  <AteRawFood.stages.ate_raw_food.label>a mangé de la viande crue</AteRawFood.stages.ate_raw_food.label>
+  <AteRawFood.stages.ate_raw_food.label>a mangé de la nourriture crue</AteRawFood.stages.ate_raw_food.label>
   <!-- EN: I had to eat raw food. We should be cooking that kind of food before eating it. We're not animals. -->
   <AteRawFood.stages.ate_raw_food.description>J'ai dû manger de la nourriture crue. Est-ce qu'on pourrait la faire cuire, ou au moins en faire de la pâte nutritive ?</AteRawFood.stages.ate_raw_food.description>
   


### PR DESCRIPTION
"ate_raw_food" est traduit par "a mangé de la viande crue", ce qui est inexact, car food = nourriture. La différence est importante car Ideology a introduit les concepts de repas végétariens, carnivores, etc...