### PR TITLE
coupeur -> scarificateur

### DIFF
--- a/Ideology/DefInjected/RitualBehaviorDef/Ritual_Behaviors.xml
+++ b/Ideology/DefInjected/RitualBehaviorDef/Ritual_Behaviors.xml
@@ -155,7 +155,7 @@
   <!-- EN: the person to scarify -->
   <ScarificationCeremony.roles.0.missingDesc>la personne à scarifier</ScarificationCeremony.roles.0.missingDesc>
   <!-- EN: cutter -->
-  <ScarificationCeremony.roles.1.label>coupeur</ScarificationCeremony.roles.1.label>
+  <ScarificationCeremony.roles.1.label>scarificateur</ScarificationCeremony.roles.1.label>
   <!-- EN: the person who performs the scarification -->
   <ScarificationCeremony.roles.1.missingDesc>la personne qui fait la scarification</ScarificationCeremony.roles.1.missingDesc>
   


### PR DESCRIPTION
Dans le cadre du riteul de scarification, "scarificateur" est plus adapté que
"coupeur".