### PR TITLE
Update Script_Hack_AncientComplex.xml

### DIFF
--- a/Ideology/DefInjected/QuestScriptDef/Script_Hack_AncientComplex.xml
+++ b/Ideology/DefInjected/QuestScriptDef/Script_Hack_AncientComplex.xml
@@ -13,7 +13,7 @@
     <li>questDescription->You've learned of an ancient complex nearby. It is said to contain information about [relic_name].\n\nIf you can break into the structure and hack the computers inside, you can collect the information.\n\nWatch out - there may be all manner of dangers inside, and other enemies may also be attracted by activity at the structure.</li>
   -->
   <AncientComplex_Standard.questDescriptionRules.rulesStrings>
-    <li>Vous avez entendu parler d'un ancien complexe à proximité. On dit qu'il contient des informations sur [relic_name].\n\nSi vous pouvez pénétrer dans la structure et pirater les ordinateurs à l'intérieur, vous pourrez collecter des informations.\n\nAttention : il peut y avoir toutes sortes de dangers à l'intérieur, et des ennemis peuvent également être attirés par l'activité au niveau de la structure.</li>
+    <li>questDescription->Vous avez entendu parler d'un ancien complexe à proximité. On dit qu'il contient des informations sur [relic_name].\n\nSi vous pouvez pénétrer dans la structure et pirater les ordinateurs à l'intérieur, vous pourrez collecter des informations.\n\nAttention : il peut y avoir toutes sortes de dangers à l'intérieur, et des ennemis peuvent également être attirés par l'activité au niveau de la structure.</li>
   </AncientComplex_Standard.questDescriptionRules.rulesStrings>
   <!-- EN:
     <li>questName(p=6)->The [complexAdj] [complex]</li>


### PR DESCRIPTION
Corrige l'erreur dans le journal d'erreur :
Translated non-System.String field rulesStrings of type System.Collections.Generic.List`1[System.String] at path AncientComplex_Standard.questDescriptionRules.rulesStrings. Expected System.String. (Script_Hack_AncientComplex.xml)