### PR TITLE
Update Designators.xml

### DIFF
--- a/Core/Keyed/Designators.xml
+++ b/Core/Keyed/Designators.xml
@@ -189,43 +189,43 @@
   <DesignatorStudyDesc>Étudiez cet objet pour en apprendre davantage à son sujet.</DesignatorStudyDesc>
 
   <!-- EN: Paint building... -->
-  <DesignatorPaintBuilding>Peindre un mur</DesignatorPaintBuilding>
+  <DesignatorPaintBuilding>Peindre une structure...</DesignatorPaintBuilding>
   <!-- EN: Designate walls and buildings to be painted using dye from tinctoria plants, which you can grow. Only certain buildings can be painted. -->
-  <DesignatorPaintBuildingDesc>Désignez les murs et les bâtiments à peindre à l’aide de teinture de tinctoria, que vous pouvez cultiver. Seuls certains bâtiments peuvent être peints.</DesignatorPaintBuildingDesc>
+  <DesignatorPaintBuildingDesc>Désigne les murs et les bâtiments à peindre en utilisant le colorant des plantes Tinctoria, que vous pouvez cultiver. Seuls certains bâtiments peuvent être peints.</DesignatorPaintBuildingDesc>
   <!-- EN: Paint floor... -->
-  <DesignatorPaintFloor>Peindre le sol</DesignatorPaintFloor>
+  <DesignatorPaintFloor>Peindre un sol...</DesignatorPaintFloor>
   <!-- EN: Designate floors to be painted using dye from tinctoria plants, which you can grow. Only certain floors can be painted. -->
-  <DesignatorPaintFloorDesc>Désignez les sols à peindre à l’aide de teinture de tinctoria, que vous pouvez cultiver. Seuls certains sols peuvent être peints.</DesignatorPaintFloorDesc>
+  <DesignatorPaintFloorDesc>Désigne les sols à peindre en utilisant le colorant des plantes Tinctoria, que vous pouvez cultiver. Seuls certains sols peuvent être peints.</DesignatorPaintFloorDesc>
 
   <!-- EN: Remove paint -->
   <DesignatorRemovePaint>Enlever la peinture</DesignatorRemovePaint>
   <!-- EN: Remove paint from walls, buildings, and floors. -->
-  <DesignatorRemovePaintDesc>Enlever la painture des murs, batiments et sols</DesignatorRemovePaintDesc>
+  <DesignatorRemovePaintDesc>Enleve la peinture des murs, batiments et sols.</DesignatorRemovePaintDesc>
   <!-- EN: Remove floor paint -->
-  <DesignatorRemoveFloorPaint>Enlever la peinture au sol</DesignatorRemoveFloorPaint> 
+  <DesignatorRemoveFloorPaint>Enlever la peinture du sol</DesignatorRemoveFloorPaint> 
   <!-- EN: Remove paint from floors. -->
-  <DesignatorRemoveFloorPaintDesc>Enlever la peinture du sol</DesignatorRemoveFloorPaintDesc> 
+  <DesignatorRemoveFloorPaintDesc>Enleve la peinture au sol.</DesignatorRemoveFloorPaintDesc> 
   <!-- EN: Paint -->
-  <Paint>Peindre</Paint>
+  <Paint>Peinture </Paint>
   <!-- EN: Color -->
   <Color>Couleur</Color>
 
   <!-- EN: Color picker -->
   <DesignatorEyedropper>Sélecteur de couleurs</DesignatorEyedropper>
   <!-- EN: Grab existing color -->
-  <GrabExistingColor>Saisir la couleur existante</GrabExistingColor>
+  <GrabExistingColor>Copier la couleur</GrabExistingColor>
   <!-- EN: Grab a color from an existing building. -->
-  <DesignatorEyeDropperDesc_Paint>Saisir la couleur d'un batiment existante.</DesignatorEyeDropperDesc_Paint>
+  <DesignatorEyeDropperDesc_Paint>Copier la peinture d'une structure.</DesignatorEyeDropperDesc_Paint>
   <!-- EN: Grab a color from an existing carpet. -->
-  <DesignatorEyeDropperDesc_Carpet>Saisir la couleur d'un sol existante.</DesignatorEyeDropperDesc_Carpet>
+  <DesignatorEyeDropperDesc_Carpet>Copier la peinture d'un sol.</DesignatorEyeDropperDesc_Carpet>
   <!-- EN: Select a painted building. -->
-  <SelectAPaintedBuilding>Sélectionnez un bâtiment peint.</SelectAPaintedBuilding>
+  <SelectAPaintedBuilding>Sélectionnez un élément avec une couleur de peinture.</SelectAPaintedBuilding>
   <!-- EN: Select colored carpet. -->
   <SelectColoredFloor>Sélectionnez un sol peint.</SelectColoredFloor>
   <!-- EN: Grab -->
-  <Grab>Saisir</Grab>
+  <Grab>Copier </Grab>
   <!-- EN: Grabbed color -->
-  <GrabbedColor>Saisir une couleur</GrabbedColor>
+  <GrabbedColor>Couleur copiée </GrabbedColor>
  
   <!-- Failure messages -->
   <!-- EN: Unchosen material -->


### PR DESCRIPTION
"Désigne" ou lieu de "Désignez" dans *Desc et pour rester cohérant avec les autres traductions du menu.
Même chose pour "Enleve" et "Enlevez"

L'espace après "Peinture " et "Couleur copiée " est volontaire car il est suivi ": NomDeLaCouleur"

J'ai remplacé "Saisir" par "Copier" car on utilise la pipette dans le jeu pour dupliquer la couleur de l'élément choisi.

"Tinctoria" j'ai mis le T en majuscule car dans la description de la plante celle-ci est présente.

