### PR TITLE
Update Misc_Gameplay.xml

### DIFF
--- a/Biotech/Keyed/Misc_Gameplay.xml
+++ b/Biotech/Keyed/Misc_Gameplay.xml
@@ -648,7 +648,7 @@
 
   <!-- Mech resurrection -->
   <!-- EN: Mech resurrection charges -->
-  <MechResurrectionCharges>Charges de résurrection mécanoïde</MechResurrectionCharges>
+  <MechResurrectionCharges>Charges de résurrection mech</MechResurrectionCharges>
 
   <!-- Mechs -->
   <!-- EN: Mech stun pulse on death -->


### PR DESCRIPTION
Texte trop grand.

"résurrection" ne passe pas sur la même ligne, même si on enlève "de" et le "s" de charges.
Avec un espace insécable le "n" de résurrection se retrouve à la ligne.

J'ai mis mech car vous l'utilisez pour ce DLC.

https://i.imgur.com/onxhxFI.jpg