### PR TITLE
Update Script_PollutionRetaliation.xml

### DIFF
--- a/Biotech/DefInjected/QuestScriptDef/Script_PollutionRetaliation.xml
+++ b/Biotech/DefInjected/QuestScriptDef/Script_PollutionRetaliation.xml
@@ -17,22 +17,15 @@
     <li>retaliationLetterText(sender_factionLeader==True)->[sender_nameFull] [sender_faction_leaderTitle] de [sender_faction_name] affirme que votre déversement imprudent de déchets toxiques hors carte a nui à sa faction. en représailles, [sender_pronoun] utilise des modules de transport pour vous bombarder de déchets toxiques.\n\nS'ils ne sont pas conservés congelés, les déchets toxiques se désagrégeront avec le temps, polluant ainsi le terrain à proximité.</li>
     <li>retaliationLetterText(sender_royalInCurrentFaction==True)->[sender_nameFull] [sender_faction_leaderTitle] de [sender_faction_name] affirme que votre déversement imprudent de déchets toxiques hors carte a nui à sa faction, et [sender_pronoun] croit qu'[sender_pronoun] est tenu par l'honneur de se venger. [sender_pronoun] utilise des modules de transport pour vous bombarder de déchets toxiques.\n\nS'ils ne sont pas conservés congelés, les déchets toxiques se désagrégeront avec le temps, polluant ainsi le terrain à proximité.</li>
   </PollutionRetaliation.questContentRules.rulesStrings>
+
   <!-- EN:
     <li>questDescription->pollutionretaliation</li>
   -->
-  <PollutionRetaliation.questDescriptionRules.rulesStrings>
-    <li>questDescription->représailles toxiques</li>
-  </PollutionRetaliation.questDescriptionRules.rulesStrings>
-  <!-- EN:
-    <li>questDescription->pollutionretaliation</li>
-  -->
-  <PollutionRetaliation.questNameRules.rulesStrings>
-    <!-- NOTE: Logiquement, cela devrait être questName ici -->
-    <li>questDescription->représailles toxiques</li>
-  </PollutionRetaliation.questNameRules.rulesStrings>
+  <PollutionRetaliation.questDescriptionRules.rulesStrings.0>questDescription->représailles toxiques</PollutionRetaliation.questDescriptionRules.rulesStrings.0> <!-- hidden -->
   
-  <!-- UNUSED -->
-  <PollutionRetaliation.questDescriptionRules.rulesStrings>représailles toxiques</PollutionRetaliation.questDescriptionRules.rulesStrings>
-  <PollutionRetaliation.questNameRules.rulesStrings>représailles toxiques</PollutionRetaliation.questNameRules.rulesStrings>
+  <!-- EN:
+    <li>questDescription->pollutionretaliation</li>
+  -->
+  <PollutionRetaliation.questNameRules.rulesStrings.0>questDescription->représailles toxiques</PollutionRetaliation.questNameRules.rulesStrings.0> <!-- hidden -->
   
 </LanguageData>


### PR DESCRIPTION
Un double dans les lignes de traduction.

Avec cette modification j'ai corrigé les erreurs :

========== Def-injected translations load errors (88) ==========
Translated non-System.String field rulesStrings of type System.Collections.Generic.List`1[System.String] at path PollutionRetaliation.questDescriptionRules.rulesStrings. Expected System.String. (Script_PollutionRetaliation.xml)
Translated non-System.String field rulesStrings of type System.Collections.Generic.List`1[System.String] at path PollutionRetaliation.questNameRules.rulesStrings. Expected System.String. (Script_PollutionRetaliation.xml)



========== Def-injected translations missing (2) ==========
QuestScriptDef: PollutionRetaliation.questDescriptionRules.rulesStrings.0 'questDescription->pollutionretaliation' (hint: this list allows full-list translation by using <li> nodes)
QuestScriptDef: PollutionRetaliation.questNameRules.rulesStrings.0 'questDescription->pollutionretaliation' (hint: this list allows full-list translation by using <li> nodes)