### PR TITLE
Update Script_EndGame_RoyalAscent.xml

### DIFF
--- a/Royalty/DefInjected/QuestScriptDef/Script_EndGame_RoyalAscent.xml
+++ b/Royalty/DefInjected/QuestScriptDef/Script_EndGame_RoyalAscent.xml
@@ -94,5 +94,5 @@
   <EndGame_RoyalAscent.root.nodes.pickupShipThingSentUnsatisfied.node.nodes.Letter.text.slateRef>La navette envoyée pour récupérer le [asker_faction_leaderTitle] est repartie sans [asker_objective]. [asker_pronoun] va devoir partir à pied maintenant. [failLetterEndingCommon]</EndGame_RoyalAscent.root.nodes.pickupShipThingSentUnsatisfied.node.nodes.Letter.text.slateRef>
   <!-- EN: The shuttle sent to collect the [asker_faction_leaderTitle] has been destroyed. [failLetterEndingCommon] -->
   <EndGame_RoyalAscent.LetterTextGuestLost.slateRef>La navette envoyée pour récupérer le [asker_faction_leaderTitle] a été détruite. [failLetterEndingCommon]</EndGame_RoyalAscent.LetterTextGuestLost.slateRef>
-
+ 
 </LanguageData>


### PR DESCRIPTION
La ligne 82 et 92 sont des doubles.

Message du fichier "TranslationReport" :
Duplicate def-injected translation key. Both EndGame_RoyalAscent.LetterLabelGuestLost.slateRef and EndGame_RoyalAscent.root.nodes.askerLeftMap.node.nodes.Letter.label.slateRef refer to the same field (EndGame_RoyalAscent.root.nodes.askerLeftMap.node.nodes.Letter.label.slateRef) (Script_EndGame_RoyalAscent.xml)