### PR TITLE
Update Script_Hospitality_Worker.xml

### DIFF
--- a/Royalty/DefInjected/QuestScriptDef/Script_Hospitality_Worker.xml
+++ b/Royalty/DefInjected/QuestScriptDef/Script_Hospitality_Worker.xml
@@ -68,5 +68,5 @@
   <Util_ArriveByDropPodsOrShuttle.LetterLabelShuttleDestroyed.slateRef>Navette détruite</Util_ArriveByDropPodsOrShuttle.LetterLabelShuttleDestroyed.slateRef>
   <!-- EN: The shuttle sent to drop off [pawnsLabelDef] has been destroyed. You have failed the quest '[resolvedQuestName]'.\n\nYour relations with [asker_faction_name] have changed by [goodwillChangeOnShuttleDestroyed]. -->
   <Util_ArriveByDropPodsOrShuttle.LetterTextShuttleDestroyed.slateRef>La navette envoyée pour débarquer [pawnsLabelDef] a été détruite. Vous avez raté la quête '[resolvedQuestName]'.\n\nVos relations avec la faction [asker_factionName] ont changé de [goodwillChangeOnShuttleDestroyed].</Util_ArriveByDropPodsOrShuttle.LetterTextShuttleDestroyed.slateRef>
-  
+   
 </LanguageData>


### PR DESCRIPTION
35 et 39 lignes en doubles


Duplicate def-injected translation key. Both Hospitality_Util_Worker.LetterLabelGuestLost.slateRef and Hospitality_Util_Worker.root.nodes.lodgersLeftMap.node.nodes.Letter.label.slateRef refer to the same field (Hospitality_Util_Worker.root.nodes.lodgersLeftMap.node.nodes.Letter.label.slateRef) (Script_Hospitality_Worker.xml)