### PR TITLE
Update Script_Intro_Wimp.xml

### DIFF
--- a/Royalty/DefInjected/QuestScriptDef/Script_Intro_Wimp.xml
+++ b/Royalty/DefInjected/QuestScriptDef/Script_Intro_Wimp.xml
@@ -89,5 +89,5 @@
   <Intro_Wimp.LetterLabelCaptured.slateRef>Invité perdu : {SUBJECT_definite}</Intro_Wimp.LetterLabelCaptured.slateRef>
   <!-- EN: {SUBJECT_definite}, who you were charged to protect, has left the designated settlement. [failLetterEndingCommon] -->
   <Intro_Wimp.LetterTextCaptured.slateRef>{SUBJECT_definite}, que vous étiez chargé de protéger, a quitté la colonie désignée. [failLetterEndingCommon]</Intro_Wimp.LetterTextCaptured.slateRef>
-  
+   
 </LanguageData>


### PR DESCRIPTION
73 et 89 lignes en doubles


Duplicate def-injected translation key. Both Intro_Wimp.root.nodes.askerArrested.node.nodes.Letter.label.slateRef and Intro_Wimp.LetterLabelCaptured.slateRef (Intro_Wimp.root.nodes.17.node.nodes.0.label.slateRef) refer to the same field (Intro_Wimp.LetterLabelCaptured.slateRef) (Script_Intro_Wimp.xml)