### PR TITLE
Translate "carabine de survie" to "fusil à verrou"

### DIFF
--- a/Core/DefInjected/RecipeDef/ImpliedDefs.xml
+++ b/Core/DefInjected/RecipeDef/ImpliedDefs.xml
@@ -317,12 +317,12 @@
   <!-- EN: En train de fabriquer pistolet automatique. -->
   <Make_Gun_Autopistol.jobString>Fabrique un pistolet automatique.</Make_Gun_Autopistol.jobString>
   
-  <!-- EN: fabriquer carabine de survie -->
-  <Make_Gun_BoltActionRifle.label>fabriquer une carabine de survie</Make_Gun_BoltActionRifle.label>
-  <!-- EN: Fabriquer une carabine de survie. -->
-  <Make_Gun_BoltActionRifle.description>Fabriquer une carabine de survie.</Make_Gun_BoltActionRifle.description>
-  <!-- EN: En train de fabriquer carabine de survie. -->
-  <Make_Gun_BoltActionRifle.jobString>Fabrique une carabine de survie.</Make_Gun_BoltActionRifle.jobString>
+  <!-- EN: fabriquer fusil à verrou -->
+  <Make_Gun_BoltActionRifle.label>fabriquer un fusil à verrou</Make_Gun_BoltActionRifle.label>
+  <!-- EN: Fabriquer un fusil à verrou. -->
+  <Make_Gun_BoltActionRifle.description>Fabriquer un fusil à verrou.</Make_Gun_BoltActionRifle.description>
+  <!-- EN: En train de fabriquer fusil à verrou. -->
+  <Make_Gun_BoltActionRifle.jobString>Fabrique un fusil à verrou.</Make_Gun_BoltActionRifle.jobString>
   
   <!-- EN: fabriquer fusil à pompe automatique -->
   <Make_Gun_ChainShotgun.label>fabriquer un fusil à pompe automatique</Make_Gun_ChainShotgun.label>

--- a/Core/DefInjected/ThingDef/RangedIndustrial.xml
+++ b/Core/DefInjected/ThingDef/RangedIndustrial.xml
@@ -8,7 +8,7 @@
   <Bullet_Autopistol.label>balle de pistolet automatique</Bullet_Autopistol.label>
   
   <!-- EN: bolt-action rifle bullet -->
-  <Bullet_BoltActionRifle.label>balle de carabine de survie</Bullet_BoltActionRifle.label>
+  <Bullet_BoltActionRifle.label>balle de fusil à verrou</Bullet_BoltActionRifle.label>
   
   <!-- EN: EMP launcher shell -->
   <Bullet_EMPLauncher.label>obus pour lanceur IEM</Bullet_EMPLauncher.label>
@@ -63,7 +63,7 @@
   <Gun_Autopistol.verbs.Verb_Shoot.label>pistolet automatique</Gun_Autopistol.verbs.Verb_Shoot.label>
   
   <!-- EN: bolt-action rifle -->
-  <Gun_BoltActionRifle.label>carabine de survie</Gun_BoltActionRifle.label>
+  <Gun_BoltActionRifle.label>fusil à verrou</Gun_BoltActionRifle.label>
   <!-- EN: An ancient pattern bolt-action rifle. With its long range, and low fire rate, it is unlikely to drive animals to revenge, which makes it a favorite weapon for hunting. -->
   <Gun_BoltActionRifle.description>Ancienne carabine à verrou. Bonne gamme, bonne puissance, à faible cadence de tir, il est peu probable que les animaux se vengeront, ce qui en fait une arme de prédilection pour la chasse.</Gun_BoltActionRifle.description>
   <!-- EN: stock -->
@@ -71,7 +71,7 @@
   <!-- EN: barrel -->
   <Gun_BoltActionRifle.tools.barrel.label>canon</Gun_BoltActionRifle.tools.barrel.label>
   <!-- EN: bolt-action rifle -->
-  <Gun_BoltActionRifle.verbs.Verb_Shoot.label>carabine de survie</Gun_BoltActionRifle.verbs.Verb_Shoot.label>
+  <Gun_BoltActionRifle.verbs.Verb_Shoot.label>fusil à verrou</Gun_BoltActionRifle.verbs.Verb_Shoot.label>
   
   <!-- EN: chain shotgun -->
   <Gun_ChainShotgun.label>fusil à pompe automatique</Gun_ChainShotgun.label>

--- a/Core/WordInfo/Gender/Female.txt
+++ b/Core/WordInfo/Gender/Female.txt
@@ -42,7 +42,7 @@ balise de commerce orbital (plan)
 balise de débarquement pour vaisseau
 balise de largage mécanoïde
 balle de canon à aiguille
-balle de carabine de survie
+balle de fusil à verrou
 balle de fusil à impulsion
 balle de fusil à pompe
 balle de fusil d'assaut
@@ -108,7 +108,6 @@ capsule d'hypersommeil
 capsule d'hypersommeil (plan)
 capsules de transport
 capuche
-carabine de survie
 carapace
 caravane
 caravane attaquée

--- a/Core/WordInfo/Gender/Male.txt
+++ b/Core/WordInfo/Gender/Male.txt
@@ -526,6 +526,7 @@ fusil à pompe
 fusil à pompe automatique
 fusil d'assaut
 fusil de précision
+fusil à verrou
 garde
 gardiens stellaires
 gardien stellaire

--- a/Core/WordInfo/Gender/Singular.txt
+++ b/Core/WordInfo/Gender/Singular.txt
@@ -79,7 +79,7 @@ balise de commerce orbital (plan)
 balise de débarquement pour vaisseau
 balise de largage mécanoïde
 balle de canon à aiguille
-balle de carabine de survie
+balle de fusil à verrou
 balle de fusil à impulsion
 balle de fusil à pompe
 balle de fusil d'assaut
@@ -308,7 +308,7 @@ capteur sonore gauche
 capteur visuel
 capuche
 capybara
-carabine de survie
+fusil à verrou
 carapace
 caravane
 caravane attaquée


### PR DESCRIPTION
La version original a été mise à jour vers fusil à verrou il y a de cela 7 ans, 

![image](https://github.com/Ludeon/RimWorld-fr/assets/56021761/ea51a514-3d50-4b95-b8bc-7e54b07c06dd)

la traduction française ne s'est pas actualisé depuis. Le terme fusil à verrou renseigne mieux sur les performances de l'arme qu'une carabine de survie qui évoque une arme plus utile en early game, ce qui peut prêté à confusion

D'autant que la description de l'arme est bien traduite par "carabine à verrou"

![image](https://github.com/Ludeon/RimWorld-fr/assets/56021761/68dbaa5c-bb29-4810-b2eb-ac3a9ad7ec38)
